### PR TITLE
Use text fields for registration

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,12 +6,12 @@
 
     <div class="field">
       <%= f.label :first_name %><br />
-      <%= f.email_field :first_name %>
+      <%= f.text_field :first_name %>
     </div>
 
     <div class="field">
       <%= f.label :last_name %><br />
-      <%= f.email_field :last_name %>
+      <%= f.text_field :last_name %>
     </div>
 
     <div class="field">


### PR DESCRIPTION
Prevents HTML errors from being thrown when using non-emails as First/ Last Names